### PR TITLE
rbindlist use.names=FALSE for data.table v1.12.4

### DIFF
--- a/R/Mashed_table.R
+++ b/R/Mashed_table.R
@@ -616,9 +616,9 @@ mash_rows <- function(dat, insert_blank_row = FALSE){
 
     dl <- c(dd, list(blank_rowks))
 
-    res <- data.table::rbindlist(dl)
+    res <- data.table::rbindlist(dl, use.names=FALSE)   
   } else {
-    res <- data.table::rbindlist(dd)
+    res <- data.table::rbindlist(dd, use.names=FALSE)
   }
 
 

--- a/R/regions.R
+++ b/R/regions.R
@@ -34,7 +34,7 @@ regions.character <- function(x){
     )
   }
 
-  data.table::rbindlist(res)
+  data.table::rbindlist(res, use.names=FALSE)
 }
 
 


### PR DESCRIPTION
Hi,
I've just submitted v1.12.2 to CRAN. There will be no impact to `tatoo`. But there is one change which will affect you in the next release v1.12.4. Of the 621 packages on CRAN using data.table, `tatoo` is the only one affected by this.  It's because your tests are so good and strict that they are detecting the new message when your test checks there should be no message. I turned off the message for automatic names (`V[0-9]+`) so `tatoo` wouldn't fail on CRAN.
Some of your rbindlist calls have a data.frame-like item with `V1,V2,V3,...` column names.  These names don't match the column names of the items being `rbind`-ed, hence the new message. 
I've checked that with this PR,  `tatoo` will pass v1.12.4.
Please see data.table news item 5 in v1.12.2 here:  https://github.com/Rdatatable/data.table/blob/master/NEWS.md
Hope this change is ok to make.
Best, Matt